### PR TITLE
Refine helper initialization and caching

### DIFF
--- a/rosetta/calc.py
+++ b/rosetta/calc.py
@@ -9,7 +9,7 @@ from rosetta.lookup import SABIAN_SYMBOLS, DIGNITIES, PLANETARY_RULERS
 
 # Force path to the ephe folder in your repo
 EPHE_PATH = os.path.join(os.path.dirname(__file__), "ephe")
-EPHE_PATH = EPHE_PATH.replace("\\", "/")
+EPHE_PATH = os.path.normpath(EPHE_PATH)
 
 
 def _get_swe():

--- a/rosetta/calc.py
+++ b/rosetta/calc.py
@@ -14,7 +14,8 @@ TESTFILE = os.path.join(EPHE_PATH, "se01181s.se1")
 
 
 def _get_swe():
-    os.environ.setdefault("SE_EPHE_PATH", EPHE_PATH)
+    # Always set the environment variable to ensure consistency with the path used by initialize_swisseph
+    os.environ["SE_EPHE_PATH"] = EPHE_PATH
     return initialize_swisseph(EPHE_PATH)
 
 SIGNS = [

--- a/rosetta/calc.py
+++ b/rosetta/calc.py
@@ -10,12 +10,9 @@ from rosetta.lookup import SABIAN_SYMBOLS, DIGNITIES, PLANETARY_RULERS
 # Force path to the ephe folder in your repo
 EPHE_PATH = os.path.join(os.path.dirname(__file__), "ephe")
 EPHE_PATH = EPHE_PATH.replace("\\", "/")
-TESTFILE = os.path.join(EPHE_PATH, "se01181s.se1")
 
 
 def _get_swe():
-    # Always set the environment variable to ensure consistency with the path used by initialize_swisseph
-    os.environ["SE_EPHE_PATH"] = EPHE_PATH
     return initialize_swisseph(EPHE_PATH)
 
 SIGNS = [

--- a/rosetta/drawing.py
+++ b/rosetta/drawing.py
@@ -1,5 +1,4 @@
 # rosetta/drawing.py
-import swisseph as swe
 import matplotlib.pyplot as plt
 from rosetta.helpers import deg_to_rad
 from rosetta.lookup import ASPECTS, GLYPHS, GROUP_COLORS

--- a/rosetta/helpers.py
+++ b/rosetta/helpers.py
@@ -53,11 +53,13 @@ def initialize_swisseph(ephemeris_path: str | None = None):
             swe.set_ephe_path(ephemeris_path)
             _swe = swe
             _swe_path = ephemeris_path
-        elif ephemeris_path is not None and ephemeris_path != _swe_path:
-            raise ValueError(
-                f"Cannot change ephemeris path after initialization. "
-                f"Current path: {_swe_path}, requested: {ephemeris_path}"
-            )
+        elif ephemeris_path is not None:
+            ephemeris_path = os.path.normpath(ephemeris_path)
+            if ephemeris_path != _swe_path:
+                raise ValueError(
+                    f"Cannot change ephemeris path after initialization. "
+                    f"Current path: {_swe_path}, requested: {ephemeris_path}"
+                )
 
         return _swe
 

--- a/rosetta/helpers.py
+++ b/rosetta/helpers.py
@@ -48,6 +48,7 @@ def initialize_swisseph(ephemeris_path: str | None = None):
 
             if ephemeris_path is None:
                 ephemeris_path = os.path.join(os.path.dirname(__file__), "ephe")
+            ephemeris_path = os.path.normpath(ephemeris_path)
 
             swe.set_ephe_path(ephemeris_path)
             _swe = swe
@@ -62,7 +63,11 @@ def initialize_swisseph(ephemeris_path: str | None = None):
 
 
 def _get_swisseph():
-    """Lazy Swiss Ephemeris accessor used internally by helper functions."""
+    """Lazy Swiss Ephemeris accessor used internally by helper functions.
+
+    This is a convenience wrapper around initialize_swisseph() that uses
+    the default ephemeris path. Returns the cached swisseph module instance.
+    """
 
     return initialize_swisseph()
 

--- a/rosetta/helpers.py
+++ b/rosetta/helpers.py
@@ -25,17 +25,17 @@ def initialize_swisseph(ephemeris_path: str | None = None):
     Heavy imports and path configuration are deferred until this function is
     explicitly called. The configured module is returned and reused on
     subsequent calls.
-    
+
     Once initialized, the ephemeris path cannot be changed. If a different
     path is provided after initialization, a ValueError is raised.
-    
+
     Args:
         ephemeris_path: Path to ephemeris data files. If None, uses default
                        path in the 'ephe' subdirectory.
-    
+
     Returns:
         The swisseph module instance.
-        
+
     Raises:
         ValueError: If attempting to change the ephemeris path after initialization.
     """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,15 +3,16 @@ import tempfile
 
 import pytest
 
+import rosetta.helpers
 from rosetta.helpers import build_aspect_graph, format_dms, load_star_df, initialize_swisseph
 
 
 @pytest.fixture(autouse=True)
 def reset_swisseph_state():
     """Reset swisseph state before each test."""
-    import rosetta.helpers
     rosetta.helpers._swe = None
     rosetta.helpers._swe_path = None
+    yield
 
 
 def _normalize_components(components):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,46 @@
+import math
+
+from rosetta.helpers import build_aspect_graph, format_dms, load_star_df
+
+
+def _normalize_components(components):
+    return sorted([tuple(sorted(component)) for component in components])
+
+
+def test_format_dms_is_deterministic():
+    values = [
+        (12.3456, {}),
+        (-0.5123, {"is_speed": True}),
+        (45.5, {"is_latlon": True}),
+    ]
+
+    for value, kwargs in values:
+        first = format_dms(value, **kwargs)
+        for _ in range(3):
+            assert format_dms(value, **kwargs) == first
+
+
+def test_build_aspect_graph_is_deterministic():
+    positions = {
+        "Sun": 0.0,
+        "Moon": 2.5,
+        "Mars": 120.0,
+        "Venus": 122.0,
+        "Jupiter": 250.0,
+    }
+
+    first = _normalize_components(build_aspect_graph(positions))
+    second = _normalize_components(build_aspect_graph(positions))
+
+    assert first == second
+    assert first == [
+        ("Mars", "Moon", "Sun", "Venus"),
+    ]
+
+
+def test_load_star_df_is_cached():
+    first = load_star_df()
+    second = load_star_df()
+
+    assert first is second
+    assert not math.isnan(first["Degree"].iloc[0])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,10 +1,17 @@
 import math
-import os
 import tempfile
 
 import pytest
 
 from rosetta.helpers import build_aspect_graph, format_dms, load_star_df, initialize_swisseph
+
+
+@pytest.fixture(autouse=True)
+def reset_swisseph_state():
+    """Reset swisseph state before each test."""
+    import rosetta.helpers
+    rosetta.helpers._swe = None
+    rosetta.helpers._swe_path = None
 
 
 def _normalize_components(components):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,8 @@
 import math
+import os
+import tempfile
+
+import pytest
 
 from rosetta.helpers import build_aspect_graph, format_dms, load_star_df, initialize_swisseph
 
@@ -65,7 +69,6 @@ def test_initialize_swisseph_is_cached():
 
 def test_initialize_swisseph_default_path():
     """Test that default ephemeris path is used when none is provided."""
-    import os
     swe = initialize_swisseph()
     # Just verify it returns a module without error
     assert swe is not None
@@ -74,9 +77,6 @@ def test_initialize_swisseph_default_path():
 
 def test_initialize_swisseph_path_immutable():
     """Test that ephemeris path cannot be changed after initialization."""
-    import pytest
-    import tempfile
-    
     # Initialize with default path (or already initialized)
     initialize_swisseph()
     

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,7 +55,7 @@ def test_load_star_df_cache_clearing():
     first = load_star_df()
     load_star_df.cache_clear()
     second = load_star_df()
-    
+
     assert first is not second  # Different instances after clear
     assert first.equals(second)  # But same data
 


### PR DESCRIPTION
## Summary
- defer Swiss Ephemeris initialization and ephemeris path configuration behind explicit helper accessors
- wrap fixed star loading in an LRU cache and remove noisy module import side effects
- add unit tests to ensure helper utilities are deterministic and cached

## Testing
- python -m pytest tests/test_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933351aaed08329b30ca9aa912b234e)